### PR TITLE
Add restart: on-failure on docker-compose 

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -14,7 +14,9 @@ func main() {
 	//start the db
 	pgdb, err := db.StartDB()
 	if err != nil {
-		log.Printf("error starting the database %v", err)
+		log.Printf("error: %v", err)
+		panic("error starting the database")
+
 	}
 	//get the router of the API by passing the db
 	router := api.StartAPI(pgdb)
@@ -24,5 +26,6 @@ func main() {
 	err = http.ListenAndServe(fmt.Sprintf(":%s", port), router)
 	if err != nil {
 		log.Printf("error from router %v\n", err)
+		return
 	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,16 @@ services:
   db:
     image: postgres
     restart: always
+    ports:
+      - 5432:5432
     environment:
       POSTGRES_PASSWORD: admin
+
   api:
     build: .
     ports:
       - 8080:8080
+    restart: on-failure:10
     environment:
       - PORT=8080
       - DATABASE_URL=db

--- a/migrations/2_comments.up.sql
+++ b/migrations/2_comments.up.sql
@@ -5,4 +5,4 @@ CREATE TABLE IF NOT EXISTS comments (
 );
 
 INSERT INTO users(name) VALUES('dev_test_user');
-INSERT INTO comments (comment) VALUES('first test comment');
+INSERT INTO comments (comment, user_id) VALUES('first test comment 1', 1);


### PR DESCRIPTION
The first time I run docker-compose it fails because postgres is not ready yet.

![Captura de tela de 2022-11-26 09-38-05](https://user-images.githubusercontent.com/19138891/204089348-372ea696-abfc-4e5f-896e-aac786f67dbe.png)

"Note that depends_on only waits for the other container to be up, but not for the process it is running to start" - [stackoverflow](https://stackoverflow.com/questions/52699899/depends-on-doesnt-wait-for-another-service-in-docker-compose-1-22-0)
